### PR TITLE
[FEATURE]: #172 implement interview scheduling with enhanced validation

### DIFF
--- a/src/main/java/org/likelion/recruit/resource/common/exception/ErrorCode.java
+++ b/src/main/java/org/likelion/recruit/resource/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
     //interview
     INTERVIEW_TIME_NOT_EXISTS(HttpStatus.NOT_FOUND, "인터뷰 시간이 존재하지 않습니다."),
+    NOT_AVAILABLE_INTERVIEW_TIME(HttpStatus.BAD_REQUEST, "지원자가 선택한 면접 가능 시간이 아닙니다."),
 
     //application
     APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 지원서가 존재합니다."),

--- a/src/main/java/org/likelion/recruit/resource/interview/controller/InterviewScheduleController.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/controller/InterviewScheduleController.java
@@ -1,0 +1,26 @@
+package org.likelion.recruit.resource.interview.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.likelion.recruit.resource.common.dto.response.ApiResponse;
+import org.likelion.recruit.resource.interview.dto.command.InterviewScheduleCommand;
+import org.likelion.recruit.resource.interview.dto.request.InterviewScheduleRequest;
+import org.likelion.recruit.resource.interview.service.command.InterviewScheduleCommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/applications")
+public class InterviewScheduleController {
+
+    private final InterviewScheduleCommandService interviewScheduleCommandService;
+
+    @PostMapping("/{applicationPublicId}/interview-schedule/detail")
+    public ResponseEntity<ApiResponse<Void>> upsertInterviewSchedule(
+            @PathVariable String applicationPublicId,
+            @Valid @RequestBody InterviewScheduleRequest request) {
+        interviewScheduleCommandService.upsertInterviewSchedule(InterviewScheduleCommand.of(applicationPublicId, request));
+        return ResponseEntity.ok(ApiResponse.success("면접 관련 정보가 성공적으로 저장되었습니다."));
+    }
+}

--- a/src/main/java/org/likelion/recruit/resource/interview/domain/InterviewSchedule.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/domain/InterviewSchedule.java
@@ -54,4 +54,9 @@ public class InterviewSchedule extends BaseTimeEntity {
     public void assignPlace(String place) {
         this.place = place;
     }
+    public void updateInterviewTime(InterviewTime interviewTime) {this.interviewTime = interviewTime;}
+    public void update(String place, InterviewTime interviewTime) {
+        this.place = place;
+        this.interviewTime = interviewTime;
+    }
 }

--- a/src/main/java/org/likelion/recruit/resource/interview/dto/command/InterviewScheduleCommand.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/dto/command/InterviewScheduleCommand.java
@@ -1,0 +1,28 @@
+package org.likelion.recruit.resource.interview.dto.command;
+
+import lombok.Getter;
+import lombok.Builder;
+import org.likelion.recruit.resource.interview.dto.request.InterviewScheduleRequest;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class InterviewScheduleCommand {
+    private String applicationPublicId;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String place;
+
+    public static InterviewScheduleCommand of(String publicId, InterviewScheduleRequest request) {
+        return InterviewScheduleCommand.builder()
+                .applicationPublicId(publicId)
+                .date(request.getDate())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
+                .place(request.getPlace())
+                .build();
+    }
+}

--- a/src/main/java/org/likelion/recruit/resource/interview/dto/request/InterviewScheduleRequest.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/dto/request/InterviewScheduleRequest.java
@@ -1,0 +1,28 @@
+package org.likelion.recruit.resource.interview.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.AssertTrue;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InterviewScheduleRequest {
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String place;
+
+    @AssertTrue(message = "면접 날짜와 시작/종료 시간은 모두 입력해야 저장 가능합니다.")
+    public boolean isValid() {
+        return date != null && startTime != null && endTime != null;
+    }
+}

--- a/src/main/java/org/likelion/recruit/resource/interview/repository/InterviewAvailableRepository.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/repository/InterviewAvailableRepository.java
@@ -8,7 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface InterviewAvailableRepository extends JpaRepository<InterviewAvailable, Long>, InterviewAvailableRepositoryCustom {
 
@@ -22,4 +26,17 @@ public interface InterviewAvailableRepository extends JpaRepository<InterviewAva
             "join fetch ia.interviewTime " +
             "where ia.application = :application")
     List<InterviewAvailable> findAllByApplication(@Param("application") Application application);
+
+    @Query("SELECT ia FROM InterviewAvailable ia " +
+            "JOIN FETCH ia.interviewTime it " +
+            "WHERE ia.application = :application " +
+            "AND it.date = :date " +
+            "AND it.startTime = :startTime " +
+            "AND it.endTime = :endTime")
+    Optional<InterviewAvailable> findByApplicationAndDateTime(
+            @Param("application") Application application,
+            @Param("date") LocalDate date,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime
+    );
 }

--- a/src/main/java/org/likelion/recruit/resource/interview/repository/InterviewScheduleRepository.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/repository/InterviewScheduleRepository.java
@@ -1,0 +1,14 @@
+package org.likelion.recruit.resource.interview.repository;
+
+import org.likelion.recruit.resource.application.domain.Application;
+import org.likelion.recruit.resource.interview.domain.InterviewSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface InterviewScheduleRepository extends JpaRepository<InterviewSchedule,Long> {
+    @Query("SELECT s FROM InterviewSchedule s JOIN FETCH s.interviewTime WHERE s.application = :application")
+    Optional<InterviewSchedule> findByApplication(@Param("application") Application application);
+}

--- a/src/main/java/org/likelion/recruit/resource/interview/service/command/InterviewScheduleCommandService.java
+++ b/src/main/java/org/likelion/recruit/resource/interview/service/command/InterviewScheduleCommandService.java
@@ -1,0 +1,62 @@
+package org.likelion.recruit.resource.interview.service.command;
+
+import lombok.RequiredArgsConstructor;
+
+import org.likelion.recruit.resource.application.domain.Application;
+import org.likelion.recruit.resource.application.repository.ApplicationRepository;
+import org.likelion.recruit.resource.common.exception.BusinessException;
+import org.likelion.recruit.resource.common.exception.ErrorCode;
+import org.likelion.recruit.resource.interview.domain.InterviewAvailable;
+import org.likelion.recruit.resource.interview.domain.InterviewSchedule;
+import org.likelion.recruit.resource.interview.domain.InterviewTime;
+import org.likelion.recruit.resource.interview.dto.command.InterviewScheduleCommand;
+import org.likelion.recruit.resource.interview.repository.InterviewAvailableRepository;
+import org.likelion.recruit.resource.interview.repository.InterviewScheduleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InterviewScheduleCommandService {
+
+    private final InterviewScheduleRepository interviewScheduleRepository;
+    private final InterviewAvailableRepository interviewAvailableRepository;
+    private final ApplicationRepository applicationRepository;
+
+    public void upsertInterviewSchedule(InterviewScheduleCommand command) {
+        Application application = findApplication(command.getApplicationPublicId());
+
+        InterviewTime selectedTime = validateAndGetInterviewTime(application, command);
+
+        saveOrUpdate(application, selectedTime, command.getPlace());
+    }
+
+    private void saveOrUpdate(Application application, InterviewTime time, String place) {
+        interviewScheduleRepository.findByApplication(application)
+                .ifPresentOrElse(
+                        schedule -> {
+                            schedule.assignPlace(place);
+                            schedule.updateInterviewTime(time);
+                        },
+                        () -> interviewScheduleRepository.save(InterviewSchedule.create(place, application, time))
+                );
+    }
+
+    private Application findApplication(String publicId) {
+        return applicationRepository.findByPublicId(publicId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_EXISTS));
+    }
+
+    private InterviewTime validateAndGetInterviewTime(Application application, InterviewScheduleCommand command) {
+        return interviewAvailableRepository
+                .findByApplicationAndDateTime(
+                        application,
+                        command.getDate(),
+                        command.getStartTime(),
+                        command.getEndTime()
+                )
+                .map(InterviewAvailable::getInterviewTime)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_AVAILABLE_INTERVIEW_TIME));
+    }
+}

--- a/src/test/java/org/likelion/recruit/resource/common/init/ApplicationFixture.java
+++ b/src/test/java/org/likelion/recruit/resource/common/init/ApplicationFixture.java
@@ -5,10 +5,10 @@ import org.likelion.recruit.resource.application.domain.Question;
 import org.likelion.recruit.resource.common.domain.Part;
 import org.likelion.recruit.resource.interview.domain.InterviewAvailable;
 import org.likelion.recruit.resource.interview.domain.InterviewTime;
+import org.likelion.recruit.resource.interview.dto.command.InterviewScheduleCommand;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class ApplicationFixture {
@@ -42,5 +42,25 @@ public class ApplicationFixture {
         InterviewAvailable available = InterviewAvailable.create(time, app);
         ReflectionTestUtils.setField(available, "id", 1L);
         return available;
+    }
+
+    public static InterviewScheduleCommand createCommand(String publicId, String place) {
+        return InterviewScheduleCommand.builder()
+                .applicationPublicId(publicId)
+                .date(LocalDate.of(2026, 1, 29))
+                .startTime(LocalTime.of(14, 0))
+                .endTime(LocalTime.of(14, 20))
+                .place(place)
+                .build();
+    }
+
+    public static InterviewScheduleCommand createCommand(String publicId, String place, LocalDate date, LocalTime startTime) {
+        return InterviewScheduleCommand.builder()
+                .applicationPublicId(publicId)
+                .date(date)
+                .startTime(startTime)
+                .endTime(startTime.plusMinutes(20))
+                .place(place)
+                .build();
     }
 }

--- a/src/test/java/org/likelion/recruit/resource/interview/controller/InterviewScheduleControllerTest.java
+++ b/src/test/java/org/likelion/recruit/resource/interview/controller/InterviewScheduleControllerTest.java
@@ -1,0 +1,102 @@
+package org.likelion.recruit.resource.interview.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.likelion.recruit.resource.interview.dto.command.InterviewScheduleCommand;
+import org.likelion.recruit.resource.interview.service.command.InterviewScheduleCommandService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(InterviewScheduleController.class)
+class InterviewScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private InterviewScheduleCommandService interviewScheduleCommandService;
+
+    @Test
+    @DisplayName("날짜, 시작 시간, 종료 시간 세트가 모두 갖춰지면 성공한다.")
+    void upsertInterviewSchedule_FullSet_Success() throws Exception {
+        // Given
+        String publicId = "app-test-1234";
+        String requestJson = """
+                {
+                    "date": "2026-01-29",
+                    "startTime": "14:00:00",
+                    "endTime": "14:20:00",
+                    "place": "J201"
+                }
+                """;
+
+        willDoNothing().given(interviewScheduleCommandService)
+                .upsertInterviewSchedule(any(InterviewScheduleCommand.class));
+
+        // When & Then
+        mockMvc.perform(post("/applications/{applicationPublicId}/interview-schedule/detail", publicId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("면접 관련 정보가 성공적으로 저장되었습니다."));
+    }
+
+    @Test
+    @DisplayName("날짜(요일)만 선택하고 시간 정보가 누락되면 VALIDATION_ERROR(400)가 발생한다.")
+    void upsertInterviewSchedule_DateOnly_Fail() throws Exception {
+        // Given
+        String publicId = "app-test-1234";
+        String dateOnlyJson = """
+                {
+                    "date": "2026-01-29",
+                    "place": "J201"
+                }
+                """;
+
+        // When & Then
+        mockMvc.perform(post("/applications/{applicationPublicId}/interview-schedule/detail", publicId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(dateOnlyJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("면접 날짜와 시작/종료 시간은 모두 입력해야 저장 가능합니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("날짜 없이 시간 정보만 입력된 경우 VALIDATION_ERROR(400)가 발생한다.")
+    void upsertInterviewSchedule_TimeOnly_Fail() throws Exception {
+        // Given
+        String publicId = "app-test-1234";
+        String timeOnlyJson = """
+                {
+                    "startTime": "14:00:00",
+                    "endTime": "14:20:00",
+                    "place": "J201"
+                }
+                """;
+
+        // When & Then
+        mockMvc.perform(post("/applications/{applicationPublicId}/interview-schedule/detail", publicId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(timeOnlyJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/org/likelion/recruit/resource/interview/service/command/InterviewScheduleCommandServiceTest.java
+++ b/src/test/java/org/likelion/recruit/resource/interview/service/command/InterviewScheduleCommandServiceTest.java
@@ -1,0 +1,111 @@
+package org.likelion.recruit.resource.interview.service.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.likelion.recruit.resource.common.init.ApplicationFixture.createCommand;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.likelion.recruit.resource.application.domain.Application;
+import org.likelion.recruit.resource.application.repository.ApplicationRepository;
+import org.likelion.recruit.resource.common.exception.BusinessException;
+import org.likelion.recruit.resource.interview.domain.InterviewAvailable;
+import org.likelion.recruit.resource.interview.domain.InterviewSchedule;
+import org.likelion.recruit.resource.interview.domain.InterviewTime;
+import org.likelion.recruit.resource.interview.dto.command.InterviewScheduleCommand;
+import org.likelion.recruit.resource.interview.repository.InterviewAvailableRepository;
+import org.likelion.recruit.resource.interview.repository.InterviewScheduleRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewScheduleCommandServiceTest {
+
+    @InjectMocks
+    private InterviewScheduleCommandService interviewScheduleCommandService;
+
+    @Mock
+    private InterviewScheduleRepository interviewScheduleRepository;
+
+    @Mock
+    private InterviewAvailableRepository interviewAvailableRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Test
+    @DisplayName("날짜와 시간 세트가 모두 있고 지원자가 선택한 시간 내라면, 일정을 성공적으로 확정(저장)한다.")
+    void upsertInterviewSchedule_FullSet_Success() {
+        // Given
+        String publicId = "app-test-1234";
+        InterviewScheduleCommand command = createCommand(publicId, "J201"); // 날짜/시간 포함된 픽스처
+
+        Application application = mock(Application.class);
+        InterviewAvailable available = mock(InterviewAvailable.class);
+        InterviewTime interviewTime = mock(InterviewTime.class);
+
+        given(applicationRepository.findByPublicId(anyString())).willReturn(Optional.of(application));
+        given(interviewAvailableRepository.findByApplicationAndDateTime(any(), any(), any(), any()))
+                .willReturn(Optional.of(available));
+        given(available.getInterviewTime()).willReturn(interviewTime);
+        given(interviewScheduleRepository.findByApplication(any())).willReturn(Optional.empty());
+
+        // When
+        interviewScheduleCommandService.upsertInterviewSchedule(command);
+
+        // Then
+        verify(interviewScheduleRepository, times(1)).save(any(InterviewSchedule.class));
+    }
+
+    @Test
+    @DisplayName("이미 일정이 존재하는 지원자의 경우, 새로운 정보로 업데이트(Update)를 수행한다.")
+    void upsertInterviewSchedule_Update_Existing() {
+        // Given
+        String publicId = "app-test-1234";
+        InterviewScheduleCommand command = createCommand(publicId, "새로운 장소");
+
+        Application application = mock(Application.class);
+        InterviewSchedule existingSchedule = mock(InterviewSchedule.class);
+        InterviewAvailable available = mock(InterviewAvailable.class);
+        InterviewTime interviewTime = mock(InterviewTime.class);
+
+        given(applicationRepository.findByPublicId(anyString())).willReturn(Optional.of(application));
+        given(interviewAvailableRepository.findByApplicationAndDateTime(any(), any(), any(), any()))
+                .willReturn(Optional.of(available));
+        given(available.getInterviewTime()).willReturn(interviewTime);
+        given(interviewScheduleRepository.findByApplication(any())).willReturn(Optional.of(existingSchedule));
+
+        // When
+        interviewScheduleCommandService.upsertInterviewSchedule(command);
+
+        // Then
+        verify(existingSchedule, times(1)).assignPlace(eq("새로운 장소"));
+        verify(existingSchedule, times(1)).updateInterviewTime(any());
+        verify(interviewScheduleRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("지원자가 선택하지 않은 날짜/시간 조합으로 확정하려 하면 예외가 발생한다.")
+    void upsertInterviewSchedule_Fail_Not_Available() {
+        // Given
+        String publicId = "app-test-1234";
+        InterviewScheduleCommand command = createCommand(publicId, "J201");
+
+        Application application = mock(Application.class);
+        given(applicationRepository.findByPublicId(anyString())).willReturn(Optional.of(application));
+        given(interviewAvailableRepository.findByApplicationAndDateTime(any(), any(), any(), any()))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> interviewScheduleCommandService.upsertInterviewSchedule(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("지원자가 선택한 면접 가능 시간이 아닙니다.");
+    }
+}


### PR DESCRIPTION
<예외 처리>
1. InterviewTime 객체' 필드 일부 누락: @AssertTrue 검증, VALIDATION_ERROR (400)
2. 지원자가 미선택한 시간 배정: InterviewAvailable 존재 확인, NOT_AVAILABLE_INTERVIEW_TIME (400)
<성공 사례 시나리오>
1. 날짜와 시간 정보만으로 일정 확정 ( 장소는 나중에 입력해도 됨)
2. 날짜, 시간, 장소를 모두 포함하여 일정 최종 확정